### PR TITLE
KVAS-1019 fix helm chart failure due to hardcoded path

### DIFF
--- a/.github/actions/create_helm_chart/action.yml
+++ b/.github/actions/create_helm_chart/action.yml
@@ -1,0 +1,63 @@
+name: Create Helm chart
+description: "Create a Helm chart and publish to the repository"
+
+inputs:
+  org:
+    required: true
+    type: string
+    description: "the name of the private org"
+  coordinator:
+    required: true
+    type: string
+    description: "the name of the repo that has helper actions in it"
+  image_tag:
+    required: true
+    description: "Image tag to use for this chart"
+  repo_name:
+    required: true
+    description: "Name of the repo that the helm chart is for"
+  ci_access_token:
+    required: true
+    description: "CI access token"
+  ci_user_name:
+    required: true
+    description: "user name to be associated with this commit"
+  ci_user_email:
+    required: true
+    description: "CI user email"
+runs:
+  using: "composite"
+  steps:
+    - run: |
+        helm repo add ikva https://${{inputs.ci_access_token}}@raw.githubusercontent.com/${{inputs.org}}/${{inputs.coordinator}}/main/charts
+        helm dependency up chart
+        rm -f chart/Chart.lock
+
+        sudo snap install yq --channel=v3/stable
+        yq w -i chart/Chart.yaml version ${{ inputs.image_tag }}
+        yq w -i chart/Chart.yaml appVersion ${{ inputs.image_tag }}
+        yq w -i chart/values.yaml imageTag ${{ inputs.image_tag }}
+        yq w -i chart/values.yaml image.tag ${{ inputs.image_tag }}
+        helm package chart
+
+        git config user.name "${{ inputs.ci_user_name }}"
+        git config user.email "${{ inputs.ci_user_email }}"
+        git add chart
+        git commit -m "[SKIP CI] Create Helm chart for ${{ inputs.repo_name }} for ${{ inputs.image_tag }}"
+
+        CHARTNAME="$(yq r chart/Chart.yaml name)"
+        echo ${CHARTNAME}
+        cp ${CHARTNAME}*.tgz ./coordinator/charts
+        cd ./coordinator
+
+        git config user.name "${{ inputs.ci_user_name }}"
+        git config user.email "${{ inputs.ci_user_email }}"
+
+        git pull origin main
+        git status
+        helm repo index charts/
+        git add charts
+        git commit -m "[SKIP CI] Update charts registry for ${CHARTNAME} to ${{ inputs.image_tag }}"
+        git push origin main
+
+      shell: bash

--- a/.github/actions/create_image_tag/action.yml
+++ b/.github/actions/create_image_tag/action.yml
@@ -1,0 +1,31 @@
+name: Create image tag
+description: "Create an image tag. This will be different for main or branches"
+
+inputs:
+  package_version:
+    required: true
+    description: "version number for main branch"
+
+outputs:
+  specific_version:
+    description: 'Current release version'
+    value: ${{ steps.compute_tag.outputs.specific_version }}
+
+runs:
+  using: "composite"
+  steps:
+    - id: compute_tag
+      run: |
+        image_tag=""
+        if [[ "$GITHUB_REF" == "refs/heads/main" ]]; then
+          image_tag="${{ inputs.package_version }}"
+        else
+          # make this a pre-release tag
+          image_tag="${{ inputs.package_version }}-$(echo -n $GITHUB_REF | sed 's|refs/heads/||' | sed 's|refs/tags/||' | sed 's|/|-|g')"
+        fi
+        echo "::set-output name=specific_version::$image_tag"
+      shell: bash
+      # this exists to support create_docker_image step until it is updated to take an input
+    - run: |
+        echo "IMAGE_TAG=${{ steps.compute_tag.outputs.specific_version }}" >> $GITHUB_ENV
+      shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,9 +83,22 @@ jobs:
       - id: put_release_version_in_env
         uses: ./coordinator/.github/actions/put_release_version_in_env
 
-      - uses: ./coordinator/.github/actions/create_docker_image_tag
+      - id: create_image_tag
+        uses: ./actions/create_image_tag
+        with:
+          package_version: ${{ steps.put_release_version_in_env.outputs.app_release_version }}
+
       - uses: ./coordinator/.github/actions/create_docker_image
-      - uses: ./coordinator/.github/actions/create_helm_chart
+      - uses: ./actions/create_helm_chart
+        with:
+          org: "${{ inputs.org }}"
+          coordinator: "${{ inputs.coordinator }}"
+          image_tag: ${{ steps.create_image_tag.outputs.specific_version }}
+          repo_name: "${{ github.event.repository.name }}"
+          ci_access_token: "${{ secrets.ci_access_token }}"
+          ci_user_email: "${{ secrets.ci_user_email }}"
+          ci_user_name: "${GITHUB_ACTOR}"
+
       - uses: ./coordinator/.github/actions/git_tag_release_version
       - uses: ./coordinator/.github/actions/update_next_version
       - uses: ./coordinator/.github/actions/prepare_release_content


### PR DESCRIPTION
The policy of creating env variables is dangerous and hard to debug.

specifically passing in variables is easy to control with reusable actions

create_helm was relying on a specific folder which was no longer true so this now uses the same parameters as other stages.

Other than using inputs there is not any change to the helm charts stage