### PR TITLE
added step to get package.json version without modifying it, and then use that when creating docker image/helm chart

### DIFF
--- a/.github/actions/get_package_version/action.yml
+++ b/.github/actions/get_package_version/action.yml
@@ -1,0 +1,14 @@
+name: Read version from package.json
+description: "Read package.json version without modifying it in any way"
+outputs:
+  package_version:
+    description: "Current version read from package.json"
+    value: ${{ steps.get_package_version.outputs.package_version }}
+runs:
+  using: "composite"
+  steps:
+    - id: get_package_version
+      run: |
+        package_version=$(cat < package.json | jq -r .version)
+        echo "::set-output name=package_version::$package_version"
+      shell: bash

--- a/.github/workflows/build-feature-branch.yml
+++ b/.github/workflows/build-feature-branch.yml
@@ -78,10 +78,13 @@ jobs:
       - id: put_release_version_in_env
         uses: ./coordinator/.github/actions/put_release_version_in_env
 
+      - id: get_package_version
+        uses: ./coordinator/.github/actions/get_package_version
+
       - id: create_image_tag
         uses: kvasira/i-github-utils/.github/actions/create_image_tag@main
         with:
-          package_version: ${{ steps.put_release_version_in_env.outputs.app_release_version }}
+          package_version: ${{ steps.get_package_version.outputs.package_version }}
 
       - uses: ./coordinator/.github/actions/create_docker_image
       - uses: kvasira/i-github-utils/.github/actions/create_helm_chart@main


### PR DESCRIPTION
Problem described in https://kvasira.atlassian.net/browse/KVAS-1444
Currently for feature branches we get `<branch-version>-<branch-name>-<branch-name>` for the chart name which is too long for kubernetes
