### PR TITLE
API-86 update dep versions before creating chart

### DIFF
--- a/.github/actions/create_api_helm_charts/action.yaml
+++ b/.github/actions/create_api_helm_charts/action.yaml
@@ -78,12 +78,13 @@ runs:
         # generate and push main chart
 
         cd ..
-        helm dependency up chart
         rm -f chart/Chart.lock
         yq w -i chart/Chart.yaml version ${{ inputs.image_tag }}
         yq w -i chart/Chart.yaml appVersion ${{ inputs.image_tag }}
         yq w -i chart/values.yaml imageTag ${{ inputs.image_tag }}
         yq w -i chart/values.yaml image.tag ${{ inputs.image_tag }}
+        yq w -i chart/Chart.yaml dependencies[].version ${{ inputs.image_tag }}
+        helm dependency up chart
         helm package chart
         git add chart
 


### PR DESCRIPTION
Update the dependencies in the parent chart to the latest sub-chart versions before attempting to build it