### PR TITLE
give retry a timeout_minutes value

### DIFF
--- a/.github/actions/update_parent_helm_chart/action.yaml
+++ b/.github/actions/update_parent_helm_chart/action.yaml
@@ -37,6 +37,7 @@ runs:
       with:
         max_attempts: 5
         shell: bash
+        timeout_minutes: 1
         command: |
             sudo snap install yq --channel=v4/stable
             helm repo add ikva https://${{inputs.ci_access_token}}@raw.githubusercontent.com/${{inputs.org}}/${{inputs.coordinator}}/main/charts


### PR DESCRIPTION
This is needed but was removed in this commit: https://github.com/kvasira/i-github-utils/commit/3f8ede19a7f3ddad97f702e987cfbb9c35d1fd77

We now have all of the required arguments: https://github.com/nick-fields/retry#timeout_minutes